### PR TITLE
fix: make req.respond() exclusive

### DIFF
--- a/benchmark/Dockerfile
+++ b/benchmark/Dockerfile
@@ -8,6 +8,6 @@ RUN curl -fsSL https://deno.land/x/install/install.sh | sh -s -- ${DENO_VERSION}
 COPY . /servest
 RUN deno fetch /servest/benchmark/listen_bench.ts \
     && deno fetch /servest/benchmark/std_bench.ts \
-    && deno fetch /servest/benchmark/msin.ts
-  ENV TARGET=/servest/benchmark/listen_bench.ts
+    && deno fetch /servest/benchmark/main.ts
+ENV TARGET=/servest/benchmark/listen_bench.ts
 CMD ["deno", "-A", "/servest/benchmark/main.ts"]

--- a/benchmark/std_bench.ts
+++ b/benchmark/std_bench.ts
@@ -1,10 +1,10 @@
 // Copyright 2019 Yusuke Sakurai. All rights reserved. MIT license.
-import { serve } from "https://deno.land/std@v0.24.0/http/server.ts";
+import { serve } from "https://deno.land/std@v0.32.0/http/server.ts";
 const body = new TextEncoder().encode("Hello World");
 const it = serve(":4500");
 async function main() {
   for await (const req of it) {
-    await req.respond({
+    req.respond({
       status: 200,
       body
     });

--- a/server_test.ts
+++ b/server_test.ts
@@ -172,7 +172,7 @@ test(async function serverConnectionClose() {
 it("handleKeepAliveConn", t => {
   t.beforeAfterAll(() => {
     port++;
-    const l = listenAndServe({ port }, req => {
+    const l = listenAndServe({ port }, async req => {
       const url = new URL(req.url, "http://dummy");
       const i = url.searchParams.get("q")!;
       req.respond({ status: 200, body: "resp:" + i });

--- a/server_test.ts
+++ b/server_test.ts
@@ -13,10 +13,13 @@ import {
 } from "./vendor/https/deno.land/std/testing/asserts.ts";
 import { encode } from "./vendor/https/deno.land/std/strings/encode.ts";
 import { createAgent } from "./agent.ts";
-import { it } from "./test_util.ts";
+import { readResponse, writeRequest } from "./serveio.ts";
+import { BufReader } from "./vendor/https/deno.land/std/io/bufio.ts";
+import { deferred } from "./vendor/https/deno.land/std/util/async.ts";
+import Buffer = Deno.Buffer;
 
 let port = 8880;
-
+setFilter("handleKeepAliveConn");
 test(async function server() {
   const listener = listenAndServe(
     {
@@ -169,26 +172,54 @@ test(async function serverConnectionClose() {
   }
 });
 
-it("handleKeepAliveConn", t => {
-  t.beforeAfterAll(() => {
-    port++;
-    const l = listenAndServe({ port }, async req => {
-      const url = new URL(req.url, "http://dummy");
-      const i = url.searchParams.get("q")!;
-      req.respond({ status: 200, body: "resp:" + i });
+function dummyConn(r: Deno.Reader, w: Deno.Writer): Deno.Conn {
+  const addr: Deno.Addr = { hostname: "0.0.0.0", port: 1, transport: "tcp" };
+  return {
+    rid: -1,
+    close(): void {},
+    closeWrite(): void {},
+    closeRead(): void {},
+    localAddr: addr,
+    remoteAddr: addr,
+    read: p => r.read(p),
+    write: p => w.write(p)
+  };
+}
+
+test("handleKeepAliveConn should respond exclusively", async () => {
+  const r = new Buffer();
+  const w = new Buffer();
+  await writeRequest(r, {
+    method: "GET",
+    url: "http://localhost/?q=1"
+  });
+  await writeRequest(r, {
+    method: "GET",
+    url: "http://localhost/?q=2"
+  });
+  await writeRequest(r, {
+    method: "GET",
+    url: "http://localhost/?q=3"
+  });
+  const d = deferred<void>();
+  let latch = 3;
+  handleKeepAliveConn(dummyConn(r, w), async req => {
+    const url = new URL(req.url, "http://dummy");
+    const i = url.searchParams.get("q")!;
+    req.respond({ status: 200, body: "resp:" + i }).then(() => {
+      if (--latch === 0) {
+        d.resolve();
+      }
     });
-    return () => l.close();
   });
-  t.run("should respond exclusively", async () => {
-    const [resp1, resp2, resp3] = await Promise.all([
-      fetch("http://localhost:" + port + "/?q=1"),
-      fetch("http://localhost:" + port + "/?q=2"),
-      fetch("http://localhost:" + port + "/?q=3")
-    ]);
-    assertEquals(await resp1.body.text(), "resp:1");
-    assertEquals(await resp2.body.text(), "resp:2");
-    assertEquals(await resp3.body.text(), "resp:3");
-  });
+  await d;
+  const responseReader = new BufReader(w);
+  const resp1 = await readResponse(responseReader);
+  assertEquals(await resp1.body.text(), "resp:1");
+  const resp2 = await readResponse(responseReader);
+  assertEquals(await resp2.body.text(), "resp:2");
+  const resp3 = await readResponse(responseReader);
+  assertEquals(await resp3.body.text(), "resp:3");
 });
 
 runIfMain(import.meta);


### PR DESCRIPTION
- BREAKING CHANGE: `req.writeTrailer()` now remove.
  - use `trailers` options in `ServerResponse`
- fix: `ServerRequest.respond()` is now exclusive.
---

Now code like below are valid handler for `ServeHandler` but is **not recommended**.
```ts
listenAndServe({...}, async req => {
  // await is optional within handler
  req.respond({status: 200, body: "ok"})
});
```

