### PR TITLE
feat: Add req.path and req.query

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -5,8 +5,7 @@ import { RoutingError } from "./error.ts";
 /** Deny request with 404 if method doesn't match */
 export const methodFilter = (...method: string[]): HttpHandler => async req => {
   if (!method.includes(req.method)) {
-    const u = new URL(req.url, "http://dummy");
-    throw new RoutingError(404, `Cannot ${req.method} ${u.pathname}`);
+    throw new RoutingError(404, `Cannot ${req.method} ${req.path}`);
   }
 };
 

--- a/router.ts
+++ b/router.ts
@@ -142,7 +142,6 @@ export function createRouter(
 
   function createHandler(): ServeHandler {
     const handleInternal = async (req: ServerRequest) => {
-      let { pathname } = new URL(req.url, "http://localhost");
       for (const middleware of middlewares) {
         await middleware({ ...req, match: [] });
         if (req.isResponded()) {
@@ -151,7 +150,7 @@ export function createRouter(
         }
       }
       const { index, match } = findLongestAndNearestMatch(
-        pathname,
+        req.path,
         routes.map(v => v.pattern)
       );
       if (index > -1 && match) {

--- a/serve_jsx.ts
+++ b/serve_jsx.ts
@@ -18,8 +18,7 @@ export function serveJsx(
   parentComponent: any = React.Fragment
 ): HttpHandler {
   return async function serveJsx(req) {
-    const { pathname } = new URL(req.url, "http://dummy");
-    const p = await resolveIndexPath(dir, pathname, [".tsx", ".jsx"]);
+    const p = await resolveIndexPath(dir, req.path, [".tsx", ".jsx"]);
     if (p) {
       const jsx = await onImport(p);
       const el = jsx.default as DFC;

--- a/serve_static.ts
+++ b/serve_static.ts
@@ -37,10 +37,9 @@ export function serveStatic(
   const filter = opts.filter || (() => true);
   return async function serveStatic(req) {
     if (req.method === "GET" || req.method === "HEAD") {
-      const { pathname } = new URL(req.url, "http://dummy");
       const filepath = await resolveIndexPath(
         dir,
-        decodeURIComponent(pathname)
+        decodeURIComponent(req.path)
       );
       if (!filepath || !(await filter(filepath))) {
         return;

--- a/serveio.ts
+++ b/serveio.ts
@@ -47,9 +47,9 @@ export function initServeOptions(opts: ServeOptions = {}): ServeOptions {
 }
 
 /**
- * read http request from reader
- * status-line and headers are certainly read. body and trailers may not be read
- * read will be aborted when opts.cancel is called or any read wait to reader is over opts.readTimeout
+ * Read http request from reader.
+ * 'status-line' and headers are certainly read. body and trailers may not be read.
+ * Read will be aborted when opts.cancel is called or any read wait to reader is over opts.readTimeout.
  * */
 export async function readRequest(
   r: Reader,
@@ -68,6 +68,7 @@ export async function readRequest(
     throw EOF;
   }
   let [_, method, url, proto] = resLine.match(/^([^ ]+)? ([^ ]+?) ([^ ]+?)$/);
+  const { searchParams: query, pathname: path } = new URL(url, "http://dummy");
   method = method.toUpperCase();
   // read header
   const headers = await promiseInterrupter({
@@ -121,6 +122,8 @@ export async function readRequest(
   return {
     method,
     url,
+    path,
+    query,
     proto,
     headers,
     cookies,

--- a/serveio_test.ts
+++ b/serveio_test.ts
@@ -30,6 +30,9 @@ test(async function serveioReadRequestGet() {
   const req = await readRequest(f);
   assertEquals(req.method, "GET");
   assertEquals(req.url, "/index.html?deno=land&msg=gogo");
+  assertEquals(req.path, "/index.html");
+  assertEquals(req.query.get("deno"), "land");
+  assertEquals(req.query.get("msg"), "gogo");
   assertEquals(req.proto, "HTTP/1.1");
   assertEquals(req.headers.get("host"), "deno.land");
   assertEquals(req.headers.get("content-type"), "text/plain");
@@ -43,6 +46,8 @@ test(async function serveioReadRequestGetCapital() {
   const req = await readRequest(f);
   assertEquals(req.method, "GET");
   assertEquals(req.url, "/About/Index.html?deno=land&msg=gogo");
+  assertEquals(req.query.get("deno"), "land");
+  assertEquals(req.query.get("msg"), "gogo");
   assertEquals(req.proto, "HTTP/1.1");
   assertEquals(req.headers.get("host"), "deno.land");
   assertEquals(req.headers.get("content-type"), "text/plain");
@@ -60,6 +65,8 @@ test(async function serveioReadRequestEncoded() {
     "/%E3%81%A7%E3%81%AE%E3%81%8F%E3%81%AB?deno=%F0%9F%A6%95"
   );
   assertEquals(req.proto, "HTTP/1.1");
+  assertEquals(req.path, "/%E3%81%A7%E3%81%AE%E3%81%8F%E3%81%AB");
+  assertEquals(req.query.get("deno"), "🦕");
   assertEquals(req.headers.get("host"), "deno.land");
   assertEquals(req.headers.get("content-type"), "text/plain");
   assert(req.body === void 0);
@@ -72,6 +79,7 @@ test(async function serveioReadRequestPost() {
   const req = await readRequest(f);
   assertEquals(req.method, "POST");
   assertEquals(req.url, "/index.html");
+  assertEquals(req.path, "/index.html");
   assertEquals(req.proto, "HTTP/1.1");
   assertEquals(req.headers.get("host"), "deno.land");
   assertEquals(req.headers.get("content-type"), "text/plain");

--- a/server.ts
+++ b/server.ts
@@ -3,7 +3,7 @@ import Conn = Deno.Conn;
 import Reader = Deno.Reader;
 import { BufReader, BufWriter } from "./vendor/https/deno.land/std/io/bufio.ts";
 import { promiseInterrupter } from "./promises.ts";
-import { Deferred, deferred } from "./vendor/https/deno.land/std/util/async.ts";
+import { deferred } from "./vendor/https/deno.land/std/util/async.ts";
 import { initServeOptions, readRequest, writeResponse } from "./serveio.ts";
 import { createResponder, ServerResponder } from "./responder.ts";
 import ListenOptions = Deno.ListenOptions;
@@ -41,8 +41,12 @@ export type ServerResponse = {
 
 /** Incoming http request for handling request from client */
 export type IncomingHttpRequest = {
-  /** request path with queries. always begin with / */
+  /** Raw requested URL (path + query): /path/to/resource?a=1&b=2 */
   url: string;
+  /** Path part of url: /path/to/resource */
+  path: string;
+  /** Query part of url: ?a=1&b=2 */
+  query: URLSearchParams;
   /** HTTP method */
   method: string;
   /** requested protocol. like HTTP/1.1 */

--- a/site/public/example/use_middleware.ts
+++ b/site/public/example/use_middleware.ts
@@ -4,8 +4,7 @@ const router = createRouter();
 // Called for every request
 router.use(async req => {
   // Do authentication before handling request on routes
-  const q = new URL(req.url, "http://dummy").searchParams;
-  const token = q.get("auth_token");
+  const token = req.query.get("auth_token");
   if (token !== "valid_token") {
     // Responded request won't be passed to the next middleware
     await req.respond({ status: 401, body: "Unauthorized" });

--- a/testing.ts
+++ b/testing.ts
@@ -60,8 +60,11 @@ export function createRecorder({
   }
   const responder = createResponder(bufWriter);
   const cookies = parseCookie(headers.get("Cookie") || "");
+  const { pathname: path, searchParams: query } = new URL(url, "http://dummy");
   return {
     url,
+    path,
+    query,
     method,
     headers,
     proto,


### PR DESCRIPTION
- `ServerRequest.path` is path part of raw url.
- `ServerRequest.query` is safely-parsed query part of raw url (`URLSearchParams`).