### PR TITLE
change: revert separation of req.match

### DIFF
--- a/agent.ts
+++ b/agent.ts
@@ -114,7 +114,7 @@ export function createAgent(
         conn: _conn,
       }));
     } catch (e) {
-      if (e === UnexpectedEofError) {
+      if (e instanceof UnexpectedEofError) {
         throw new ConnectionClosedError();
       } else {
         throw e;

--- a/router_test.ts
+++ b/router_test.ts
@@ -32,8 +32,8 @@ group("router", (t) => {
     router.handle(new RegExp("^/Var"), async (req) => {
       await req.respond({ status: 200, body: req.url });
     });
-    router.handle(new RegExp("/foo/(?<id>.+)"), async (req, params) => {
-      const { id } = params.match.groups!;
+    router.handle(new RegExp("^/foo/(?<id>.+)"), async (req) => {
+      const { id } = req.match.groups!;
       await req.respond({
         status: 200,
         headers: new Headers({

--- a/site/index.ts
+++ b/site/index.ts
@@ -14,8 +14,8 @@ app.use(serveStatic(resolve("./public")));
 app.use(serveJsx(resolve("./pages"), (f) => import(f), Layout));
 app.get(
   new RegExp("^/@(?<version>.*?)/(?<pathname>.+?)$"),
-  async (req, { match }) => {
-    let { version, pathname } = match.groups!;
+  async (req) => {
+    let { version, pathname } = req.match.groups!;
     if (!version) {
       version = "master";
     }

--- a/site/public/example/app_server.ts
+++ b/site/public/example/app_server.ts
@@ -15,8 +15,8 @@ app.get("/", async (req) => {
 // Define route with regexp pattern.
 // Called if request path matches regex.
 // If multiple route matches path, the longest match route will be called.
-app.get(new RegExp("^/foo/(.+)"), async (req, { match }) => {
-  const [_, id] = match;
+app.get(new RegExp("^/foo/(.+)"), async (req) => {
+  const [_, id] = req.match;
   await req.respond({
     status: 200,
     headers: new Headers({

--- a/site/public/example/manage_session.ts
+++ b/site/public/example/manage_session.ts
@@ -38,8 +38,8 @@ app.use(async (req) => {
   // save session to store
   sessionMap.set(req, session);
 });
-app.get("/", async (req, { match }) => {
-  const [_, id] = match;
+app.get("/", async (req) => {
+  const [_, id] = req.match;
   await req.respond({
     status: 200,
     headers: new Headers({

--- a/site/public/example/use_router.ts
+++ b/site/public/example/use_router.ts
@@ -21,7 +21,7 @@ function UserRoutes() {
     // POST /users
   });
   router.get("/sign_in", (req) => {
-    // POST /sign_in,
+    // GET /users/sign_in,
   });
   function UserPostRoutes() {
     const router = createRouter();

--- a/testing.ts
+++ b/testing.ts
@@ -19,6 +19,7 @@ import {
 } from "./vendor/https/deno.land/std/http/io.ts";
 import { createBodyParser, BodyParser } from "./body_parser.ts";
 import { createDataHolder } from "./data_holder.ts";
+import { assert } from "./vendor/https/deno.land/std/testing/asserts.ts";
 
 export type ResponseRecorder = ServerRequest & {
   /** Obtain recorded response */
@@ -84,6 +85,8 @@ export function createRecorder({
   const cookies = parseCookie(headers.get("Cookie") || "");
   const { pathname: path, searchParams: query } = new URL(url, "http://dummy");
   const dataHolder = createDataHolder();
+  const match = url.match(/^\//);
+  assert(match != null);
   return {
     url,
     path,
@@ -97,6 +100,7 @@ export function createRecorder({
     bufReader,
     conn,
     cookies,
+    match,
     ...responder,
     ...bodyParser,
     ...dataHolder,


### PR DESCRIPTION
- In #87, `RoutedServerRequest.match` was separated into second argument of route handler. 
- Now `match` is re-composed into `ServerRequest`