### PR TITLE
Server displays `listening on undefined:8899`

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -79,7 +79,7 @@ export function createApp(
     opts?: ServeOptions,
   ): ServeListener {
     const listener = listenAndServe(addr, (req) => handleRoute("", req), opts);
-    info(`listening on ${addr.hostname}:${addr.port}`);
+    info(`listening on ${addr.hostname || ""}:${addr.port}`);
     return listener;
   }
   function listenTls(


### PR DESCRIPTION
I try to run that script

```tsx
// @deno-types="https://servestjs.org/@v1.0.0-rc2/types/react/index.d.ts"
import React from "https://dev.jspm.io/react/index.js";
// @deno-types="https://servestjs.org/@v1.0.0-rc2/types/react-dom/server/index.d.ts"
import ReactDOMServer from "https://dev.jspm.io/react-dom/server.js";
import { createApp } from "https://servestjs.org/@v1.0.0-rc2/mod.ts";

const app = createApp();
app.handle("/", async (req) => {
  await req.respond({
    status: 200,
    headers: new Headers({
      "content-type": "text/html; charset=UTF-8",
    }),
    body: ReactDOMServer.renderToString(
      <html>
        <head>
          <meta charSet="utf-8" />
          <title>servest</title>
        </head>
        <body>Hello Servest!</body>
      </html>,
    ),
  });
});
app.listen({ port: 8899 });
```

run servest server by this command 

```bash
deno run --allow-net index.tsx
```

Result:
```[2020-05-13T07:29:17.508Z] servest:router listening on undefined:8899```

So i create this PR to fix the issue.

Deno version: 1.0.0-rc3