### PR TITLE
chore: Remove unused imported function

### DIFF
--- a/serveio_test.ts
+++ b/serveio_test.ts
@@ -8,10 +8,7 @@ import {
   writeRequest,
   writeResponse,
 } from "./serveio.ts";
-import {
-  assert,
-  assertEquals,
-} from "./vendor/https/deno.land/std/testing/asserts.ts";
+import { assertEquals } from "./vendor/https/deno.land/std/testing/asserts.ts";
 import { StringReader } from "./vendor/https/deno.land/std/io/readers.ts";
 import { encode } from "./vendor/https/deno.land/std/encoding/utf8.ts";
 import Buffer = Deno.Buffer;


### PR DESCRIPTION
`assert` doesn't seem to be used.