### PR TITLE
fix declare closeWrite

### DIFF
--- a/testing.ts
+++ b/testing.ts
@@ -42,7 +42,7 @@ export function createRecorder(opts?: {
     remoteAddr: { transport: "tcp", hostname: "0.0.0.0", port: 80 },
     rid: 0,
     close(): void {},
-    closeWrite(): void {},
+    async closeWrite(): Promise<void> {},
     async read(p: Uint8Array): Promise<number | null> {
       return 0;
     },


### PR DESCRIPTION
I wrote short program. But, I cannot start server with error.

```
import { createApp } from "https://deno.land/x/servest/mod.ts";

const app = createApp();
app.handle("/", async req => {
  await req.respond({
    status: 200,
    headers: new Headers({
      "content-type": "text/html; charset=UTF-8"
    }),
    body: "hello World!",
  });
});
app.listen({port: 8888});
```

This is output log.

```
$ deno run --allow-net servest.ts
Check file:///home/kotauchisunsun/work/*****/servest.ts
error: TS2322 [ERROR]: Type '() => void' is not assignable to type '() => Promise<void>'.
  Type 'void' is not assignable to type 'Promise<void>'.
    closeWrite(): void {},
    ~~~~~~~~~~
    at https://deno.land/x/servest@v1.1.8/testing.ts:45:5
```

I executed this program with Deno 1.7.1 on WSL2.

```
$ deno --version
deno 1.7.1 (release, x86_64-unknown-linux-gnu)
v8 8.9.255.3
typescript 4.1.3
```

I modified testing.ts to start program.

Deno.con must have `closeWrite(): Promise<void>`
https://doc.deno.land/builtin/stable#Deno.Conn