### PR TITLE
Sending allowed methods if not requested a specific ones

### DIFF
--- a/middleware/cors.ts
+++ b/middleware/cors.ts
@@ -81,7 +81,7 @@ export function cors({
         withCredentials.toString(),
       );
       req.responseHeaders.set("access-control-max-age", `${maxAge}`);
-
+      
       return req.respond({ status: 204 });
     } else { //actual response
       setAccessControlAllowOrigin(origin, requestOrigin, req);
@@ -136,6 +136,11 @@ function setAccessControlRequestMethods(methods: string[], req: ServerRequest) {
     req.responseHeaders.set(
       "access-control-allow-methods",
       allowed.join(", "),
+    );
+  } else {
+    req.responseHeaders.set(
+      "access-control-allow-methods",
+      methods.join(", "),
     );
   }
 }

--- a/middleware/cors.ts
+++ b/middleware/cors.ts
@@ -81,7 +81,7 @@ export function cors({
         withCredentials.toString(),
       );
       req.responseHeaders.set("access-control-max-age", `${maxAge}`);
-      
+
       return req.respond({ status: 204 });
     } else { //actual response
       setAccessControlAllowOrigin(origin, requestOrigin, req);

--- a/middleware/cors.ts
+++ b/middleware/cors.ts
@@ -72,7 +72,7 @@ export function cors({
         req,
       );
       if (isValidOrigin === false) return;
-      setAccessControlRequestMethods(methods, req);
+      setAccessControlRequestMethod(methods, req);
       setAccessControlRequestHeaders(allowedHeaders, req);
       setAcessControlExposeHeaders(exposedHeaders, req);
 
@@ -128,19 +128,14 @@ function setAccessControlAllowOrigin(
   }
 }
 
-function setAccessControlRequestMethods(methods: string[], req: ServerRequest) {
-  const requestMethods = req.headers.get("access-control-request-methods");
+function setAccessControlRequestMethod(methods: string[], req: ServerRequest) {
+  const requestMethods = req.headers.get("access-control-request-method");
   if (requestMethods && methods.length > 0) {
     const list = requestMethods.split(",").map((v) => v.trim());
     const allowed = list.filter((v) => methods.includes(v));
     req.responseHeaders.set(
       "access-control-allow-methods",
       allowed.join(", "),
-    );
-  } else {
-    req.responseHeaders.set(
-      "access-control-allow-methods",
-      methods.join(", "),
     );
   }
 }

--- a/middleware/cors.ts
+++ b/middleware/cors.ts
@@ -66,21 +66,30 @@ export function cors({
       return;
     }
     if (req.method === "OPTIONS") { //preflight
-      const isValidOrigin = setAccessControlAllowOrigin(origin, requestOrigin, req);
-      if(isValidOrigin === false) return;
+      const isValidOrigin = setAccessControlAllowOrigin(
+        origin,
+        requestOrigin,
+        req,
+      );
+      if (isValidOrigin === false) return;
       setAccessControlRequestMethods(methods, req);
       setAccessControlRequestHeaders(allowedHeaders, req);
       setAcessControlExposeHeaders(exposedHeaders, req);
 
-      req.responseHeaders.set("access-control-allow-credentials", withCredentials.toString());
+      req.responseHeaders.set(
+        "access-control-allow-credentials",
+        withCredentials.toString(),
+      );
       req.responseHeaders.set("access-control-max-age", `${maxAge}`);
 
       return req.respond({ status: 204 });
     } else { //actual response
       setAccessControlAllowOrigin(origin, requestOrigin, req);
       setAcessControlExposeHeaders(exposedHeaders, req);
-      req.responseHeaders.set("access-control-allow-credentials", withCredentials.toString());
-
+      req.responseHeaders.set(
+        "access-control-allow-credentials",
+        withCredentials.toString(),
+      );
     }
   };
 }

--- a/middleware/cors.ts
+++ b/middleware/cors.ts
@@ -70,7 +70,7 @@ export function cors({
       if(isValidOrigin === false) return;
       setAccessControlRequestMethods(methods, req);
       setAccessControlRequestHeaders(allowedHeaders, req);
-      setAcessControllExposedHeaders(exposedHeaders, req);
+      setAcessControlExposeHeaders(exposedHeaders, req);
 
       req.responseHeaders.set("access-control-allow-credentials", withCredentials.toString());
       req.responseHeaders.set("access-control-max-age", `${maxAge}`);
@@ -78,7 +78,7 @@ export function cors({
       return req.respond({ status: 204 });
     } else { //actual response
       setAccessControlAllowOrigin(origin, requestOrigin, req);
-      setAcessControllExposedHeaders(exposedHeaders, req);
+      setAcessControlExposeHeaders(exposedHeaders, req);
       req.responseHeaders.set("access-control-allow-credentials", withCredentials.toString());
 
     }
@@ -131,7 +131,7 @@ function setAccessControlRequestMethods(methods: string[], req: ServerRequest) {
   }
 }
 
-function setAcessControllExposedHeaders(
+function setAcessControlExposeHeaders(
   exposedHeaders: string[],
   req: ServerRequest,
 ) {

--- a/middleware/cors.ts
+++ b/middleware/cors.ts
@@ -1,33 +1,53 @@
 // Copyright 2019-2020 Yusuke Sakurai. All rights reserved. MIT license.
-import { ServeHandler } from "../server.ts";
+import { ServeHandler, ServerRequest } from "../server.ts";
 type OriginVerifier = string | RegExp | ((s: string) => boolean);
 export interface CORSOptions {
   /**
    * verifier for Access-Control-Allow-Origin
+   * Specifies either a single origin, which tells browsers to allow that
+   * origin to access the resource; or else — for requests without
+   * credentials — the "*" wildcard, to tell browsers to allow any origin
+   * to access the resource.
    */
   origin: OriginVerifier | OriginVerifier[];
   /**
-   * values for Access-Control-Allow-Method
+   * Values for Access-Control-Allow-Methods.
+   * Specifies the method or methods allowed when accessing the resource.
+   * This is used in response to a preflight request.
+   *
    * @default none
    */
   methods?: string[];
   /**
-   * values for Access-Control-Allow-Headers
+   * Values for Access-Control-Allow-Headers.
+   * Is used in response to a preflight request to indicate which HTTP headers
+   * can be used when making the actual request. This header is the server side
+   * response to the browser's Access-Control-Request-Headers header
    * @default none
    */
   allowedHeaders?: string[];
   /**
-   * values for Access-Control-Expose-Headers
+   * Values for Access-Control-Expose-Headers.
+   * Lets a server whitelist headers that Javascript
+   * (such as getResponseHeader()) in browsers are allowed to access.
    * @default none
    */
   exposedHeaders?: string[];
   /**
-   * values for Access-Control-Allow-Credentials
+   * Value for Access-Control-Allow-Credentials.
+   * Indicates whether or not the response to the request can be exposed when
+   * the credentials flag is true. When used as part of a response to a preflight
+   * request, this indicates whether or not the actual request can be made using
+   * credentials. Note that simple GET requests are not preflighted, and so if a
+   * request is made for a resource with credentials, if this header is not
+   * returned with the resource, the response is ignored by the browser and not
+   * returned to web content.
    * @default none
    */
-  credentials?: boolean;
+  withCredentials?: boolean;
   /**
-   * values for Access-Control-Max-Age
+   * Values for Access-Control-Max-Age.
+   * Indicates how long the results of a preflight request can be cached.
    * @default 0
    */
   maxAge?: number;
@@ -37,51 +57,30 @@ export function cors({
   methods = [],
   allowedHeaders = [],
   exposedHeaders = [],
-  credentials = false,
+  withCredentials = false,
   maxAge = 0,
 }: CORSOptions): ServeHandler {
   return (req) => {
-    if (req.method === "OPTIONS") {
-      const requestOrigin = req.headers.get("origin");
-      if (!requestOrigin) {
-        return;
-      }
-      if (origin === "*") {
-        req.responseHeaders.set("access-control-allow-origin", "*");
-      } else if (verifyOrigin(origin, requestOrigin)) {
-        req.responseHeaders.set("access-control-allow-origin", requestOrigin);
-      } else {
-        return;
-      }
-      const requestMethods = req.headers.get("access-control-request-methods");
-      if (requestMethods && methods.length > 0) {
-        const list = requestMethods.split(",").map((v) => v.trim());
-        const allowed = list.filter((v) => methods.includes(v));
-        req.responseHeaders.set(
-          "access-control-allow-methods",
-          allowed.join(", "),
-        );
-      }
-      const requestHeaders = req.headers.get("access-control-request-headers");
-      if (requestHeaders && allowedHeaders.length > 0) {
-        const list = requestHeaders.split(",").map((v) => v.trim());
-        const allowed = list.filter((v) => allowedHeaders.includes(v));
-        req.responseHeaders.set(
-          "access-control-allow-headers",
-          allowed.join(", "),
-        );
-      }
-      if (exposedHeaders.length > 0) {
-        req.responseHeaders.set(
-          "accessl-control-expose-headers",
-          exposedHeaders.join(", "),
-        );
-      }
-      if (credentials) {
-        req.responseHeaders.set("access-control-allow-credentials", "true");
-      }
+    const requestOrigin = req.headers.get("origin");
+    if (!requestOrigin) {
+      return;
+    }
+    if (req.method === "OPTIONS") { //preflight
+      const isValidOrigin = setAccessControlAllowOrigin(origin, requestOrigin, req);
+      if(isValidOrigin === false) return;
+      setAccessControlRequestMethods(methods, req);
+      setAccessControlRequestHeaders(allowedHeaders, req);
+      setAcessControllExposedHeaders(exposedHeaders, req);
+
+      req.responseHeaders.set("access-control-allow-credentials", withCredentials.toString());
       req.responseHeaders.set("access-control-max-age", `${maxAge}`);
+
       return req.respond({ status: 204 });
+    } else { //actual response
+      setAccessControlAllowOrigin(origin, requestOrigin, req);
+      setAcessControllExposedHeaders(exposedHeaders, req);
+      req.responseHeaders.set("access-control-allow-credentials", withCredentials.toString());
+
     }
   };
 }
@@ -104,4 +103,57 @@ function verifyOrigin(
     }
   }
   return false;
+}
+
+function setAccessControlAllowOrigin(
+  origin: OriginVerifier | OriginVerifier[],
+  requestOrigin: string,
+  req: ServerRequest,
+) {
+  if (origin === "*") {
+    req.responseHeaders.set("access-control-allow-origin", "*");
+  } else if (verifyOrigin(origin, requestOrigin)) {
+    req.responseHeaders.set("access-control-allow-origin", requestOrigin);
+  } else {
+    return false;
+  }
+}
+
+function setAccessControlRequestMethods(methods: string[], req: ServerRequest) {
+  const requestMethods = req.headers.get("access-control-request-methods");
+  if (requestMethods && methods.length > 0) {
+    const list = requestMethods.split(",").map((v) => v.trim());
+    const allowed = list.filter((v) => methods.includes(v));
+    req.responseHeaders.set(
+      "access-control-allow-methods",
+      allowed.join(", "),
+    );
+  }
+}
+
+function setAcessControllExposedHeaders(
+  exposedHeaders: string[],
+  req: ServerRequest,
+) {
+  if (exposedHeaders.length > 0) {
+    req.responseHeaders.set(
+      "access-control-expose-headers",
+      exposedHeaders.join(", "),
+    );
+  }
+}
+
+function setAccessControlRequestHeaders(
+  allowedHeaders: string[],
+  req: ServerRequest,
+) {
+  const requestHeaders = req.headers.get("access-control-request-headers");
+  if (requestHeaders && allowedHeaders.length > 0) {
+    const list = requestHeaders.split(",").map((v) => v.trim());
+    const allowed = list.filter((v) => allowedHeaders.includes(v));
+    req.responseHeaders.set(
+      "access-control-allow-headers",
+      allowed.join(", "),
+    );
+  }
 }

--- a/middleware/cors_test.ts
+++ b/middleware/cors_test.ts
@@ -9,7 +9,7 @@ group("cors", (t) => {
       method: "OPTIONS",
       headers: new Headers({
         "origin": "https://servestjs.org",
-        "access-control-request-methods": "GET,HEAD,POST",
+        "access-control-request-method": "GET",
         "access-control-request-headers": "x-servest-version",
       }),
     });
@@ -30,7 +30,7 @@ group("cors", (t) => {
     );
     assertEquals(
       resp.headers.get("access-control-allow-methods"),
-      "GET, HEAD",
+      "GET",
     );
     assertEquals(
       resp.headers.get("access-control-allow-headers"),

--- a/middleware/cors_test.ts
+++ b/middleware/cors_test.ts
@@ -18,7 +18,7 @@ group("cors", (t) => {
       methods: ["GET", "HEAD"],
       allowedHeaders: ["x-servest-version", "x-deno-version"],
       exposedHeaders: ["x-node-version"],
-      credentials: true,
+      withCredentials: true,
       maxAge: 100,
     });
     await m(r);
@@ -45,6 +45,7 @@ group("cors", (t) => {
       "100",
     );
   });
+
   t.test("shouldn't respond if method is not OPTIONS", () => {
     const m = cors({ origin: "*" });
     const r = createRecorder();
@@ -52,6 +53,7 @@ group("cors", (t) => {
     assertEquals(r.isResponded(), false);
     assertEquals(r.responseHeaders.has("access-control-allow-origin"), false);
   });
+
   t.test("shouldn't respond if origin isn't sent", async () => {
     const m = cors({ origin: "*" });
     const r = createRecorder({ method: "OPTIONS" });
@@ -59,6 +61,7 @@ group("cors", (t) => {
     assertEquals(r.isResponded(), false);
     assertEquals(r.responseHeaders.has("access-control-allow-origin"), false);
   });
+
   t.test("shouldn't allow if origin is not verified", async () => {
     const m = cors({ origin: "https://servestjs.org" });
     const r = createRecorder({
@@ -71,6 +74,7 @@ group("cors", (t) => {
     assertEquals(r.isResponded(), false);
     assertEquals(r.responseHeaders.has("access-control-allow-origin"), false);
   });
+
   t.test("wildcard", async () => {
     const m = cors({ origin: "*" });
     const r = createRecorder({
@@ -83,6 +87,7 @@ group("cors", (t) => {
     assertEquals(r.respondedStatus(), 204);
     assertEquals(r.responseHeaders.get("access-control-allow-origin"), "*");
   });
+
   t.test("verifiers", async () => {
     for (
       const origin of [
@@ -108,5 +113,35 @@ group("cors", (t) => {
         "https://servestjs.org",
       );
     }
+  });
+
+  t.test("Should respond the correct access-control-allow-origin header on other methods", async () => {
+    const m = cors({ origin: "*" });
+    const r = createRecorder({
+      method: "POST",
+      headers: new Headers({
+        "origin": "https://servestjs.org",
+      }),
+    });
+    await m(r);
+    assertEquals(r.responseHeaders.get("access-control-allow-origin"), "*");
+  });
+
+  t.test("Should respond the correct access-control-expose-headers header on other methods", async () => {
+    const m = cors({
+      origin: "*",
+      exposedHeaders: ["x-node-version"],
+    });
+    const r = createRecorder({
+      method: "POST",
+      headers: new Headers({
+        "origin": "https://servestjs.org",
+      }),
+    });
+    await m(r);
+    assertEquals(
+      r.responseHeaders.get("access-control-expose-headers"),
+      "x-node-version",
+    );
   });
 });


### PR DESCRIPTION
When sending an Angular http PUT request, there is not header automatically added **access-control-request-methods**, and since this is not requesting an specific method, the header **access-control-allow-methods** is not populated causing a CORS error (_Method PUT is not allowed by Access-Control-Allow-Methods in preflight response_), so to fix this, in case there is not method requested, all the allowed methods are added as access-control-allow-methods, this fixes this problem.

<img width="781" alt="Captura de Pantalla 2021-07-22 a la(s) 15 24 53" src="https://user-images.githubusercontent.com/5265383/126704897-c63f546f-73b6-4707-b7c1-a635e0273f4c.png">
