### PR TITLE
Mention that the same version of middleware must be used

### DIFF
--- a/site/pages/handle-cors.tsx
+++ b/site/pages/handle-cors.tsx
@@ -17,6 +17,7 @@ const HandleCors: DFC<{
           <DocLink file="middleware/cors.ts">cors</DocLink>
           is built-in middleware for CORS (cross-origin resource sharing).
         </p>
+        <p>Note: The same version for Servest and CORS middleware must be use</p>
         <Code
           href={"/example/handle_cors.ts"}
           code={codes["handle_cors.ts"]}


### PR DESCRIPTION
Mention that the same version of CORS middleware and Servest must be used.